### PR TITLE
makefile: Reorder file to provide default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,11 @@ BUILD_DEPS = erlfmt
 
 dep_erlfmt = git https://github.com/WhatsApp/erlfmt.git v0.8.0
 
+include erlang.mk
+
 erlfmt:
 	$(gen_verbose) $(SHELL_ERL) -pa $(SHELL_PATHS) -eval 'erlfmt_cli:do("erlfmt", [write, {files, ["src/*.erl", "tests/*.erl"]} ]), halt(0)'
 
 erlfmt_check:
 	$(gen_verbose) $(SHELL_ERL) -pa $(SHELL_PATHS) -eval 'erlfmt_cli:do("erlfmt", [check, {files, ["src/*.erl", "tests/*.erl"]} ]), halt(0)'
 
-include erlang.mk


### PR DESCRIPTION
Otherwise including this lib doesn't work as erlfmt is run instead of
compiling anything here